### PR TITLE
Add message effect id for text messages

### DIFF
--- a/options.go
+++ b/options.go
@@ -49,6 +49,14 @@ func Placeholder(text string) *SendOptions {
 	}
 }
 
+// EffectID is used to set a message effect identifier as a send option.
+// It enables calls like: b.Send(recipient, "text", tele.EffectID("str_id")).
+func EffectID(id string) *SendOptions {
+	return &SendOptions{
+		EffectID: id,
+	}
+}
+
 // SendOptions has most complete control over in what way the message
 // must be sent, providing an API-complete set of custom properties
 // and options.


### PR DESCRIPTION
Add `EffectID` helper to allow setting a message effect identifier when sending messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-601827a8-abdd-4d23-a25c-b76f6cfee523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-601827a8-abdd-4d23-a25c-b76f6cfee523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

